### PR TITLE
Fix routing for one-off requests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,15 @@ pub struct Client<E> {
     _marker: std::marker::PhantomData<fn(E) -> ()>,
 }
 
+impl<E: Error> Default for Client<E> {
+    fn default() -> Self {
+        Self {
+            inner: surf::Config::new().try_into().unwrap(),
+            _marker: Default::default(),
+        }
+    }
+}
+
 impl<E: Error> Client<E> {
     /// Create a client and connect to the Tide Disco server at `base_url`.
     pub fn new(base_url: Url) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,12 +30,12 @@ pub use surf::{
 
 /// Build an HTTP `GET` request.
 pub fn get<T: DeserializeOwned, E: Error>(url: Url) -> Request<T, E> {
-    Client::new(url).get("/")
+    Client::default().get(url.as_ref())
 }
 
 /// Build an HTTP `POST` request.
 pub fn post<T: DeserializeOwned, E: Error>(url: Url) -> Request<T, E> {
-    Client::new(url).post("/")
+    Client::default().post(url.as_ref())
 }
 
 /// Connect to a server, retrying if the server is not running.


### PR DESCRIPTION
Adding a trailing / to a URI breaks route parsing in the Tide Disco server. Instead, for one-off requests, we create a client with _no_ base URL and use the entire URL of the route as the request URI.